### PR TITLE
Refactor abstract client constructor

### DIFF
--- a/src/Glassboxx/Request/AbstractRequest.php
+++ b/src/Glassboxx/Request/AbstractRequest.php
@@ -13,13 +13,17 @@ abstract class AbstractRequest
 {
     use UsesConfigTrait;
 
-    public const BASE_URL = 'https://server.glassboxx.co.uk/rest/V1';
+    public const BASE_URL = 'https://server.glassboxx.co.uk';
 
     /** @var HttpClient */
     protected $client;
 
-    public function __construct(HttpClientInterface $client)
+    public function __construct(HttpClientInterface $client = null)
     {
+        if (!$client) {
+            $client = HttpClient::createForBaseUri(self::BASE_URL);
+        }
+
         $this->client = $client;
     }
 }

--- a/src/Glassboxx/Request/AuthTokenRequest.php
+++ b/src/Glassboxx/Request/AuthTokenRequest.php
@@ -10,7 +10,7 @@ final class AuthTokenRequest extends AbstractRequest implements AuthTokenRequest
     {
         $response = $this->client->request(
             'POST',
-            self::BASE_URL.self::ENDPOINT,
+            self::ENDPOINT,
             [
                 'query' => [
                     'password' => $this->config->getPassword(),

--- a/src/Glassboxx/Request/AuthTokenRequestInterface.php
+++ b/src/Glassboxx/Request/AuthTokenRequestInterface.php
@@ -6,7 +6,7 @@ namespace Opdavies\Glassboxx\Request;
 
 interface AuthTokenRequestInterface
 {
-    public const ENDPOINT = '/integration/admin/token';
+    public const ENDPOINT = '/rest/V1/integration/admin/token';
 
     public function getToken(): string;
 }

--- a/src/Glassboxx/Request/CustomerRequest.php
+++ b/src/Glassboxx/Request/CustomerRequest.php
@@ -34,7 +34,7 @@ final class CustomerRequest extends AbstractRequest implements CustomerRequestIn
 
         $response = $this->client->request(
             'POST',
-            self::BASE_URL . self::ENDPOINT,
+            self::ENDPOINT,
             [
                 'auth_bearer' => $this->authToken,
                 'headers' => [

--- a/src/Glassboxx/Request/CustomerRequestInterface.php
+++ b/src/Glassboxx/Request/CustomerRequestInterface.php
@@ -8,7 +8,7 @@ use Opdavies\Glassboxx\ValueObject\CustomerInterface;
 
 interface CustomerRequestInterface
 {
-    public const ENDPOINT = '/glassboxxorder/customCustomer';
+    public const ENDPOINT = '/rest/V1/glassboxxorder/customCustomer';
 
     public function forCustomer(CustomerInterface $customer): AbstractRequest;
 

--- a/src/Glassboxx/Request/OrderRequest.php
+++ b/src/Glassboxx/Request/OrderRequest.php
@@ -47,7 +47,7 @@ class OrderRequest extends AbstractRequest implements OrderRequestInterface
 
         $response = $this->client->request(
             'POST',
-            self::BASE_URL . self::ENDPOINT,
+            self::ENDPOINT,
             [
                 'auth_bearer' => $this->authToken,
                 'headers' => [

--- a/src/Glassboxx/Request/OrderRequestInterface.php
+++ b/src/Glassboxx/Request/OrderRequestInterface.php
@@ -8,7 +8,7 @@ use Opdavies\Glassboxx\ValueObject\OrderInterface;
 
 interface OrderRequestInterface
 {
-    public const ENDPOINT = '/glassboxxorder/toglassboxx';
+    public const ENDPOINT = '/rest/V1/glassboxxorder/toglassboxx';
 
     public function forOrder(OrderInterface $order): AbstractRequest;
 

--- a/tests/Glassboxx/Request/AuthTokenRequestTest.php
+++ b/tests/Glassboxx/Request/AuthTokenRequestTest.php
@@ -22,8 +22,7 @@ class AuthTokenRequestTest extends TestCase
             ->method('request')
             ->with(
                 'POST',
-                AuthTokenRequest::BASE_URL
-                .AuthTokenRequest::ENDPOINT,
+                AuthTokenRequest::ENDPOINT,
                 [
                     'query' => [
                         'password' => 'secret',

--- a/tests/Glassboxx/Request/CustomerRequestTest.php
+++ b/tests/Glassboxx/Request/CustomerRequestTest.php
@@ -16,11 +16,7 @@ final class CustomerRequestTest extends TestCase
 {
     public function testThatItCreatesACustomer(): void
     {
-        $authTokenRequest = $this->getMockBuilder(AuthTokenRequestInterface::class)
-            ->getMock();
-        $authTokenRequest->expects($this->any())
-            ->method('getToken')
-            ->willReturn('testtoken');
+        $authTokenRequest = $this->getMockAuthTokenRequest();
 
         $response = $this->getMockBuilder(ResponseInterface::class)
             ->getMock();

--- a/tests/Glassboxx/Request/CustomerRequestTest.php
+++ b/tests/Glassboxx/Request/CustomerRequestTest.php
@@ -31,8 +31,7 @@ final class CustomerRequestTest extends TestCase
             ->method('request')
             ->with(
                 'POST',
-                CustomerRequest::BASE_URL
-                .CustomerRequest::ENDPOINT,
+                CustomerRequest::ENDPOINT,
                 [
                     'auth_bearer' => $authTokenRequest->getToken(),
                     'headers' => [

--- a/tests/Glassboxx/Request/OrderRequestTest.php
+++ b/tests/Glassboxx/Request/OrderRequestTest.php
@@ -43,8 +43,7 @@ final class OrderRequestTest extends TestCase
             ->method('request')
             ->with(
                 'POST',
-                OrderRequest::BASE_URL
-                .OrderRequest::ENDPOINT,
+                OrderRequest::ENDPOINT,
                 [
                     'auth_bearer' => $authTokenRequest->getToken(),
                     'headers' => [

--- a/tests/Glassboxx/Request/OrderRequestTest.php
+++ b/tests/Glassboxx/Request/OrderRequestTest.php
@@ -26,7 +26,7 @@ final class OrderRequestTest extends TestCase
                     'duration_for_loan' => 0,
                     'hostname' => 123,
                     'original_order_number' => 'abc123',
-                    'price_incl_tax' => 100,
+                    'price_incl_tax' => 7.99,
                     'sku' => 'this-is-the-first-sku',
                     'type_of_interaction' => 'purchase',
                 ],

--- a/tests/Glassboxx/TestCase.php
+++ b/tests/Glassboxx/TestCase.php
@@ -60,7 +60,7 @@ class TestCase extends \PHPUnit\Framework\TestCase
         $order->method('getCurrencyCode')->willReturn('GBP');
         $order->method('getCustomer')->willReturn($this->getMockCustomer());
         $order->method('getOrderNumber')->willReturn('abc123');
-        $order->method('getPrice')->willReturn((float) 100);
+        $order->method('getPrice')->willReturn(7.99);
         $order->method('getSku')->willReturn('this-is-the-first-sku');
 
         return $order;


### PR DESCRIPTION
Make the Client parameter optional when creating auth token, customer or
order requests, and create a new Client instance within the abstract
request if one isn't passed in.
